### PR TITLE
add persistence to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM node
-
+ENV PERSISTENCE_LOCATION=/data
 EXPOSE 3000
 
-RUN groupadd osweather && useradd --no-log-init -m -g osweather osweather
+RUN groupadd osweather && useradd --no-log-init -m -g osweather osweather && \
+    mkdir /data && \
+    chown osweather:osweather /data
+
 USER osweather
+VOLUME /data
 
 ADD --chown=osweather:osweather . weather
 

--- a/routes/geocoders/Geocoder.ts
+++ b/routes/geocoders/Geocoder.ts
@@ -5,7 +5,7 @@ import { CodedError, ErrorCode } from "../../errors";
 
 export abstract class Geocoder {
 
-	private static cacheFile: string = __dirname + "/../../../geocoderCache.json";
+	private static cacheFile: string = (process.env.PERSISTENCE_LOCATION || __dirname + "/../../..") + "/geocoderCache.json";
 
 	private cache: Map<string, GeoCoordinates>;
 

--- a/routes/weatherProviders/local.ts
+++ b/routes/weatherProviders/local.ts
@@ -38,7 +38,8 @@ export const captureWUStream = async function( req: express.Request, res: expres
 };
 
 export default class LocalWeatherProvider extends WeatherProvider {
-
+    public static observationsFile: string = ( process.env.PERSISTENCE_LOCATION ? process.env.PERSISTENCE_LOCATION + "/observations.json" : "observations.json");
+    
 	public async getWeatherData( coordinates: GeoCoordinates ): Promise< WeatherData > {
 		queue = queue.filter( obs => moment().unix() - obs.timestamp  < 24*60*60 );
 
@@ -126,16 +127,16 @@ export default class LocalWeatherProvider extends WeatherProvider {
 function saveQueue() {
 	queue = queue.filter( obs => moment().unix() - obs.timestamp  < 24*60*60 );
 	try {
-		fs.writeFileSync( "observations.json" , JSON.stringify( queue ), "utf8" );
+		fs.writeFileSync( LocalWeatherProvider.observationsFile , JSON.stringify( queue ), "utf8" );
 	} catch ( err ) {
 		console.error( "Error saving historical observations to local storage.", err );
 	}
 }
 
-if ( process.env.WEATHER_PROVIDER === "local" && process.env.LOCAL_PERSISTENCE ) {
-	if ( fs.existsSync( "observations.json" ) ) {
+if ( process.env.WEATHER_PROVIDER === "local" && (process.env.LOCAL_PERSISTENCE || process.env.PERSISTENCE_LOCATION) ) {
+	if ( fs.existsSync( LocalWeatherProvider.observationsFile ) ) {
 		try {
-			queue = JSON.parse( fs.readFileSync( "observations.json", "utf8" ) );
+			queue = JSON.parse( fs.readFileSync( LocalWeatherProvider.observationsFile, "utf8" ) );
 			queue = queue.filter( obs => moment().unix() - obs.timestamp  < 24*60*60 );
 		} catch ( err ) {
 			console.error( "Error reading historical observations from local storage.", err );


### PR DESCRIPTION
Hey,

every time I recreated my docker container I had to wait 24 hours until enough data has been collected to return some zimmermann calculation.

Persisting the observations in the containers working directory has been a good start, but didn't help in my case.

I added another environment Variable which is making the user able to define a different directory storing observations.json and geocoderCache.json.

- process.env.PERSISTENCE_LOCATION

Furthermore I extended the Dockerfile. It is preset to use an anonymous volume storing those files. Its mounted into /data.

Regards
