### PR TITLE
Add support for enabling PWS with local persistence

### DIFF
--- a/routes/weatherProviders/local.ts
+++ b/routes/weatherProviders/local.ts
@@ -132,7 +132,7 @@ function saveQueue() {
 	}
 }
 
-if ( process.env.WEATHER_PROVIDER === "local" && process.env.LOCAL_PERSISTENCE ) {
+if ( process.env.PWS && process.env.LOCAL_PERSISTENCE ) {
 	if ( fs.existsSync( "observations.json" ) ) {
 		try {
 			queue = JSON.parse( fs.readFileSync( "observations.json", "utf8" ) );


### PR DESCRIPTION
If a `PWS` (Personal Weather Station) is configured (currently, only the `WU` type is recognized by the code), OpenSprinkler-Weather will automatically register the route `/weatherstation/updateweatherstation.php` to capture the WU data stream.

However, it only saves changes from the captured stream if the `WEATHER_PROVIDER` is set to `local`. In my opinion, this is too restrictive, as one might want to collect observations before switching to the local weather provider.

Therefore, I suggest testing for the presence of the `PWS` variable instead, allowing the capturing system to function fully without requiring a provider switch.