### PR TITLE
Restore WU adjustments without solar data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "os-weather-service",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "os-weather-service",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
         "@types/qs": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "os-weather-service",
   "description": "OpenSprinkler Weather Service",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "repository": "https://github.com/OpenSprinkler/OpenSprinkler-Weather",
   "engines": {
     "node": ">=24"

--- a/src/routes/adjustmentMethods/EToAdjustmentMethod.spec.ts
+++ b/src/routes/adjustmentMethods/EToAdjustmentMethod.spec.ts
@@ -72,15 +72,44 @@ describe( "ETo AdjustmentMethod", () => {
 			makeWateringData({ maxHumidity: 101 }),
 			ErrorCode.BadWeatherData
 		);
-		await expectAdjustmentError(
-			makeAdjustmentOptions(0.15),
-			makeWateringData({ windSpeed: undefined, solarRadiation: undefined }),
-			ErrorCode.BadWeatherData
-		);
+		await expectAdjustmentError(makeAdjustmentOptions(0.15), makeWateringData({ windSpeed: -1 }), ErrorCode.BadWeatherData);
+		await expectAdjustmentError(makeAdjustmentOptions(0.15), makeWateringData({ solarRadiation: NaN }), ErrorCode.BadWeatherData);
 	});
 
-	it("uses the valid leading history when an older day lacks ETo inputs", async () => {
-		const newest = makeWateringData();
+	it("uses zero for unavailable ETo wind and solar measurements", async () => {
+		for (const missing of [
+			{ windSpeed: undefined },
+			{ solarRadiation: undefined },
+			{ windSpeed: undefined, solarRadiation: undefined },
+		]) {
+			const result = await EToAdjustmentMethod.calculateWateringScale(
+				makeAdjustmentOptions(0.15),
+				[42, -75],
+				new StaticWeatherProvider([makeWateringData(missing)])
+			);
+
+			expect(result.scale).to.be.finite;
+			expect(result.scales).to.have.length(1);
+			expect(result.wateringData[0].windSpeed).to.equal("windSpeed" in missing ? 0 : 3);
+			expect(result.wateringData[0].solarRadiation).to.equal("solarRadiation" in missing ? 0 : 5);
+		}
+	});
+
+	it("reports the effective ETo fallback inputs", async () => {
+		const source = makeWateringData({ windSpeed: undefined, solarRadiation: undefined });
+		const result = await EToAdjustmentMethod.calculateWateringScale(
+			makeAdjustmentOptions(0.15),
+			[42, -75],
+			new StaticWeatherProvider([source])
+		);
+
+		expect(result.rawData).to.include({ wind: 0, radiation: 0 });
+		expect(source.windSpeed).to.equal(undefined);
+		expect(source.solarRadiation).to.equal(undefined);
+	});
+
+	it("uses zero when an ETo measurement is unavailable throughout history", async () => {
+		const newest = makeWateringData({ solarRadiation: undefined });
 		const older = makeWateringData({
 			periodStartTime: Date.parse("2026-06-14T04:00:00Z") / 1000,
 			solarRadiation: undefined,
@@ -91,9 +120,41 @@ describe( "ETo AdjustmentMethod", () => {
 			new StaticWeatherProvider([newest, older])
 		);
 
-		expect(result.scale).to.be.finite;
+		expect(result.scales).to.have.length(2);
+		expect(result.wateringData.map(day => day.solarRadiation)).to.deep.equal([0, 0]);
+	});
+
+	it("truncates history at an intermittent ETo measurement gap", async () => {
+		const newest = makeWateringData();
+		const missing = makeWateringData({
+			periodStartTime: Date.parse("2026-06-14T04:00:00Z") / 1000,
+			solarRadiation: undefined,
+		});
+		const oldest = makeWateringData({
+			periodStartTime: Date.parse("2026-06-13T04:00:00Z") / 1000,
+		});
+		const result = await EToAdjustmentMethod.calculateWateringScale(
+			makeAdjustmentOptions(0.15),
+			[42, -75],
+			new StaticWeatherProvider([newest, missing, oldest])
+		);
+
 		expect(result.scales).to.have.length(1);
 		expect(result.wateringData).to.deep.equal([newest]);
+	});
+
+	it("rejects a newest-day gap when older history has that ETo measurement", async () => {
+		const newest = makeWateringData({ solarRadiation: undefined });
+		const older = makeWateringData({
+			periodStartTime: Date.parse("2026-06-14T04:00:00Z") / 1000,
+		});
+
+		await expectAdjustmentError(
+			makeAdjustmentOptions(0.15),
+			newest,
+			ErrorCode.BadWeatherData,
+			[older]
+		);
 	});
 } );
 
@@ -124,13 +185,18 @@ function makeAdjustmentOptions(baseETo: number): EToScalingAdjustmentOptions {
 	};
 }
 
-async function expectAdjustmentError(options: EToScalingAdjustmentOptions, data: WateringData, expected: ErrorCode) {
+async function expectAdjustmentError(
+	options: EToScalingAdjustmentOptions,
+	data: WateringData,
+	expected: ErrorCode,
+	additionalData: WateringData[] = []
+) {
 	let actual: ErrorCode | undefined;
 	try {
 		await EToAdjustmentMethod.calculateWateringScale(
 			options,
 			[42, -75],
-			new StaticWeatherProvider([data])
+			new StaticWeatherProvider([data, ...additionalData])
 		);
 	} catch (err) {
 		actual = (err as { errCode?: ErrorCode }).errCode;

--- a/src/routes/adjustmentMethods/EToAdjustmentMethod.ts
+++ b/src/routes/adjustmentMethods/EToAdjustmentMethod.ts
@@ -21,7 +21,10 @@ async function calculateEToWateringScale(
 
 	// This will throw a CodedError if ETo data cannot be retrieved.
 	const data = await weatherProvider.getWateringData( coordinates, pws );
-	const wateringData: readonly WateringData[] = data.value;
+	// Some personal weather stations do not report wind or solar measurements. Preserve the
+	// historical zero-value fallback only for ETo calculations; provider data remains honest
+	// so weather sensors can distinguish unavailable measurements from measured zero values.
+	const wateringData = applyEToCompatibilityDefaults(data.value);
 
 	let baseETo: number;
 	// Default elevation is based on data from https://www.pnas.org/content/95/24/14009.
@@ -92,6 +95,17 @@ async function calculateEToWateringScale(
 		scales: scales,
 		ttl: data.ttl,
 	}
+}
+
+function applyEToCompatibilityDefaults(history: readonly WateringData[]): WateringData[] {
+	const windUnavailable = history.every(day => day.windSpeed == null);
+	const solarUnavailable = history.every(day => day.solarRadiation == null);
+
+	return history.map(day => ({
+		...day,
+		windSpeed: windUnavailable ? 0 : day.windSpeed,
+		solarRadiation: solarUnavailable ? 0 : day.solarRadiation,
+	}));
 }
 
 /* The implementation of this algorithm was guided by a step-by-step breakdown

--- a/src/routes/weather.spec.ts
+++ b/src/routes/weather.spec.ts
@@ -84,6 +84,30 @@ describe("Watering Data", () => {
 		expect(result.rawData).to.eql({ wp: "mock", h: 50, p: 0, t: 58.3 });
 	});
 
+	it("calculates Zimmerman adjustment without wind or solar measurements", async () => {
+		const provider = new MockWeatherProvider({
+			wateringData: [{
+				weatherProvider: "mock",
+				temp: 70,
+				humidity: 30,
+				precip: 0,
+				periodStartTime: 1557622800,
+				minTemp: 60,
+				maxTemp: 80,
+				minHumidity: 20,
+				maxHumidity: 40,
+			}],
+		});
+
+		const result = await ZimmermanAdjustmentMethod.calculateWateringScale(
+			{} as any,
+			[42, -75],
+			provider
+		);
+
+		expect(result.scale).to.equal(100);
+	});
+
 	it("sorts daily history newest-first before calculating rolling averages", async () => {
 		const makeDay = (periodStartTime: number, temp: number): WateringData => ({
 			weatherProvider: "mock",

--- a/src/routes/weatherProviders/WUnderground.ts
+++ b/src/routes/weatherProviders/WUnderground.ts
@@ -53,12 +53,12 @@ export default class WUndergroundWeatherProvider extends WeatherProvider {
 			const minHumidity = minFinite(day.map(hour => hour.humidityLow));
 			const maxHumidity = maxFinite(day.map(hour => hour.humidityHigh));
 
-			if ([temp, humidity, precip, minTemp, maxTemp, wind, solar, minHumidity, maxHumidity]
+			if ([temp, humidity, precip, minTemp, maxTemp, minHumidity, maxHumidity]
 				.some(value => !Number.isFinite(value))) {
 				throw new CodedError(ErrorCode.InsufficientWeatherData);
 			}
 
-			data.push( {
+			const wateringData: WateringData = {
 				weatherProvider: "WU",
 				temp: temp,
 				humidity: humidity,
@@ -68,12 +68,17 @@ export default class WUndergroundWeatherProvider extends WeatherProvider {
 				maxTemp: maxTemp,
 				minHumidity: minHumidity,
 				maxHumidity: maxHumidity,
+			};
+			if (typeof solar === "number" && Number.isFinite(solar)) {
 				// The API exposes hourly peak irradiance, not an hourly mean. Treating each peak
 				// as a one-hour mean is retained as a documented approximation.
-				solarRadiation: solar / 1000,
+				wateringData.solarRadiation = solar / 1000;
+			}
+			if (typeof wind === "number" && Number.isFinite(wind)) {
 				// PWS anemometer height is installation-specific.
-				windSpeed: wind
-			} );
+				wateringData.windSpeed = wind;
+			}
+			data.push(wateringData);
 		}
 
 		return data.reverse();

--- a/src/routes/weatherProviders/weatherProviders.spec.ts
+++ b/src/routes/weatherProviders/weatherProviders.spec.ts
@@ -254,6 +254,32 @@ describe("Weather provider normalization", () => {
 		expect(data[0].solarRadiation).to.equal(2.4);
 	});
 
+	it("keeps Weather Underground history when wind and solar measurements are unavailable", async () => {
+		MockDate.set("2026-08-07T12:00:00Z");
+		const firstHour = getUnixTime(startOfDay(localTime(coordinates))) - 24 * 60 * 60;
+		const observations = sequence(24, i => ({
+			epoch: firstHour + i * 60 * 60,
+			tz: "America/New_York",
+			humidityAvg: 50,
+			humidityLow: 40,
+			humidityHigh: 60,
+			solarRadiationHigh: null,
+			imperial: {
+				tempAvg: 70,
+				tempLow: 60,
+				tempHigh: 80,
+				precipTotal: i / 100,
+			},
+		}));
+
+		globalThis.fetch = (async () => jsonResponse({ observations })) as typeof globalThis.fetch;
+		const data = await new TestWUndergroundProvider().readWatering(coordinates);
+		expect(data).to.have.length(1);
+		expect(data[0]).to.include({ temp: 70, humidity: 50, precip: 0.23 });
+		expect(data[0]).not.to.have.property("windSpeed");
+		expect(data[0]).not.to.have.property("solarRadiation");
+	});
+
 	it("uses Bright Sky measured solar energy and standardized 10-meter wind", async () => {
 		MockDate.set("2026-08-07T12:00:00Z");
 		const firstHour = getUnixTime(startOfDay(localTime(coordinates))) - 24 * 60 * 60;


### PR DESCRIPTION
## Summary

- restore Zimmerman and ETo adjustments for Weather Underground stations that do not report optional solar or wind measurements
- apply the legacy zero fallback only when a measurement is unavailable throughout the returned history
- preserve 3.1.0 truncation and error behavior for intermittent sensor gaps
- keep provider cache values unchanged so WeatherSensor output still distinguishes unavailable measurements from measured zeroes
- prepare Weather Server 3.1.1

## Regression

Weather Server 3.1.0 required WU wind and solar values while constructing daily history. Stations without a solar sensor therefore returned error 10 for both Zimmerman and ETo, even though Zimmerman does not use those fields and older versions treated missing ETo inputs as zero.

## Validation

- npm ci
- npm test: 75 passing
- npx tsc --noEmit
- npm run build
- npm audit --omit=dev: 0 vulnerabilities
- replayed the reporter's 155-observation WU payload through /1, /3 JSON, /3 legacy format, and /weatherSensorData
- verified intermittent middle-day gaps truncate history and newest-day gaps remain errors